### PR TITLE
removed completely unused `fs-plus` dependencie

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "atom": ">0.39.0"
   },
   "dependencies": {
-    "fs-plus": "^2",
     "temp": "0.6.0"
   }
 }


### PR DESCRIPTION
The uses from `fs-plus` were removed from the code before but the dependency was still there.